### PR TITLE
Start blacklists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "registries_verifier"
+version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This repository holds files of metadata about Bluetooth entities. The
 [Web Bluetooth specification](https://github.com/WebBluetoothCG/registries)
-refers to this repository for information that may change after it's published.
+refers to this repository for information that may change after it's published
+and defines the file formats here.
 
 ## Blacklist
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# registries
-A collection of registries, for use in the Web Bluetooth spec
+# Web Bluetooth Registries
+
+This repository holds files of metadata about Bluetooth entities. The
+[Web Bluetooth specification](https://github.com/WebBluetoothCG/registries)
+refers to this repository for information that may change after it's published.
+
+## Blacklist
+
+[gatt_blacklist.txt](/WebBluetoothCG/registries/blob/master/gatt_blacklist.txt)
+holds a list of 128-bit GATT UUIDs that
+websites using the Web Bluetooth API are forbidden from accessing.
+This includes all of Services, Characteristics, and Descriptors.
+
+This file contains comments in lines starting with `#`.
+Non-comment lines contain a [valid UUID](https://webbluetoothcg.github.io/web-bluetooth/#dfn-valid-uuid)
+followed optionally by a space and one of the tokens "`exclude-reads`" or "`excludes-writes`".

--- a/gatt_blacklist.txt
+++ b/gatt_blacklist.txt
@@ -1,0 +1,32 @@
+# This file holds a list of GATT UUIDs that websites using the Web
+# Bluetooth API are forbidden from accessing.
+
+## Services
+
+# org.bluetooth.service.human_interface_device
+# Direct access to HID devices like keyboards would let web pages
+# become keyloggers.
+00001812-0000-1000-8000-00805f9b34fb
+
+
+## Characteristics
+
+# org.bluetooth.characteristic.gap.peripheral_privacy_flag
+# Don't let web pages turn off privacy mode.
+00002a02-0000-1000-8000-00805f9b34fb exclude-writes
+
+# org.bluetooth.characteristic.gap.reconnection_address
+# Disallow messing with connection parameters
+00002a03-0000-1000-8000-00805f9b34fb
+
+
+## Descriptors
+
+# org.bluetooth.descriptor.gatt.client_characteristic_configuration
+# Writing to this would let a web page interfere with other pages'
+# notifications and indications.
+00002902-0000-1000-8000-00805f9b34fb exclude-writes
+
+# org.bluetooth.descriptor.gatt.server_characteristic_configuration
+# Writing to this would let a web page interfere with the broadcasted services.
+00002903-0000-1000-8000-00805f9b34fb exclude-writes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,124 @@
+/// Checks whether its argument is a valid UUID, per
+/// https://webbluetoothcg.github.io/web-bluetooth/#dfn-valid-uuid
+pub fn valid_uuid(uuid: &str) -> bool {
+    if uuid.len() != 36 {
+        return false;
+    }
+    for (index, char) in uuid.chars().enumerate() {
+        match index {
+            8 | 13 | 18 | 23 => {
+                if char != '-' {
+                    return false;
+                }
+            }
+            _ => {
+                match char {
+                    '0' ... '9' | 'a' ... 'f' => (),
+                    _ => return false,
+                }
+            }
+        }
+    }
+    return true;
+}
+
+/// Checks whether its argument is a blacklist file that's usable in the algorithm at
+/// https://webbluetoothcg.github.io/web-bluetooth/#dfn-parsing-the-blacklist
+pub fn validate_blacklist(blacklist: &str) -> Option<String> {
+    for (index, line) in blacklist.lines().enumerate() {
+        let line_num = index + 1;
+        if line.is_empty() || line.starts_with("#") {
+            // Comment or blank line.
+            continue;
+        }
+        let tokens: Vec<&str> = line.split(' ').collect();
+        match tokens.len() {
+            0 => unreachable!("split(' ') never returns an empty array"),
+            1 | 2 => {
+                let uuid = tokens[0];
+                if !valid_uuid(uuid) {
+                    return Some(format!("line {}: '{}' is not a valid UUID", line_num, uuid));
+                }
+                if tokens.len() == 2 {
+                    let exclusion = tokens[1];
+                    match exclusion {
+                        "exclude-reads" | "exclude-writes" => (),
+                        _ => return Some(format!(
+			    "line {}: '{}' should be 'exclude-reads', or 'exclude-writes'",
+			    line_num, exclusion)),
+                    }
+                }
+            },
+            _ => return Some(format!("line {}: Too many tokens", line_num)),
+        }
+    }
+    return None;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::prelude::*;
+
+    #[test]
+    fn test_valid_uuid() {
+	assert!( valid_uuid("00000000-0000-0000-0000-000000000000"));
+	assert!( valid_uuid("01234567-89ab-cdef-0123-456789abcdef"));
+	assert!(!valid_uuid("01234567-89AB-CDEF-0123-456789ABCDEF"));
+	assert!(!valid_uuid("g1234567-89ab-cdef-0123-456789abcdef"));
+	assert!(!valid_uuid("01234567-89ab-cdef-0123-456789abcdef0"));
+	assert!(!valid_uuid("0123456789abcdef0123456789abcdef"));
+	assert!(!valid_uuid("01234567089ab0cdef001230456789abcdef"));
+    }
+
+    #[test]
+    fn test_validate_blacklist() {
+        assert_eq!(None, validate_blacklist(""));
+        // Lines are terminated by \n, not \r\n.
+        assert_eq!(Some("line 1: '\r' is not a valid UUID".to_string()),
+                   validate_blacklist("\r\n"));
+        assert_eq!(None, validate_blacklist("# comment"));
+        assert_eq!(None, validate_blacklist("# comment
+00001812-0000-1000-8000-00805f9b34fb"));
+        // No extraneous spaces.
+        assert_eq!(Some("line 1: Too many tokens".to_string()),
+		   validate_blacklist("  # comment
+  00001812-0000-1000-8000-00805f9b34fb"));
+        assert_eq!(
+	    Some("line 1: Too many tokens".to_string()),
+	    validate_blacklist("00001812-0000-1000-8000-00805f9b34fb # not a comment"));
+        assert_eq!(
+            Some("line 1: 'X0001812-0000-1000-8000-00805f9b34fb' is not a valid UUID".to_string()),
+            validate_blacklist("X0001812-0000-1000-8000-00805f9b34fb"));
+        assert_eq!(None,
+                   validate_blacklist("00001812-0000-1000-8000-00805f9b34fb exclude-reads"));
+        assert_eq!(None,
+                   validate_blacklist("00001812-0000-1000-8000-00805f9b34fb exclude-writes"));
+        assert_eq!(
+            Some("line 1: '00001812-0000-1000-8000-00805f9b34fb\u{A0}exclude-reads' is not a valid UUID".to_string()),
+            validate_blacklist("00001812-0000-1000-8000-00805f9b34fb\u{A0}exclude-reads"));
+        assert_eq!(
+            Some("line 1: 'X0001812-0000-1000-8000-00805f9b34fb' is not a valid UUID".to_string()),
+            validate_blacklist("X0001812-0000-1000-8000-00805f9b34fb exclude-reads"));
+        assert_eq!(
+            Some("line 1: 'exclude' should be 'exclude-reads', or 'exclude-writes'".to_string()),
+            validate_blacklist("00001812-0000-1000-8000-00805f9b34fb exclude"));
+        assert_eq!(Some("line 1: Too many tokens".to_string()),
+                   validate_blacklist("00001812-0000-1000-8000-00805f9b34fb token token"));
+    }
+
+    #[test]
+    fn validate_gatt_blacklist() {
+	let filename = "gatt_blacklist.txt";
+        let content = File::open(filename).and_then(|mut file| {
+            let mut result = String::new();
+            try!(file.read_to_string(&mut result));
+            Ok(result)
+        }).unwrap_or_else(|e| { panic!("Error reading {}: {}", filename, e) });
+
+        if let Some(error) = validate_blacklist(&content) {
+	    panic!("{} is invalid: {}", filename, error);
+	}
+    }
+}


### PR DESCRIPTION
@scheib @marcoscaceres 

This complements https://github.com/WebBluetoothCG/web-bluetooth/pull/146.

The Travis CI validator script is currently in [Rust](http://www.rust-lang.org/). I'm not certain that's the right language and could switch if folks prefer. I think we should use a statically-typed language in general, but, for comparison a Go script is in https://github.com/jyasskin/registries/tree/go-blacklist-validator.
