### PR TITLE
Block the GAP and GATT services.

### DIFF
--- a/gatt_blacklist.txt
+++ b/gatt_blacklist.txt
@@ -3,6 +3,15 @@
 
 ## Services
 
+# org.bluetooth.service.generic_access and
+# org.bluetooth.service.generic_attribute
+# These fundamental services are part of the GATT protocol rather than
+# per-device data. Several platforms don't allow the browser to access them
+# directly, and most of their data is exposed through other properties on the
+# BluetoothDevice.
+00001800-0000-1000-8000-00805f9b34fb
+00001801-0000-1000-8000-00805f9b34fb
+
 # org.bluetooth.service.human_interface_device
 # Direct access to HID devices like keyboards would let web pages
 # become keyloggers.
@@ -10,14 +19,6 @@
 
 
 ## Characteristics
-
-# org.bluetooth.characteristic.gap.peripheral_privacy_flag
-# Don't let web pages turn off privacy mode.
-00002a02-0000-1000-8000-00805f9b34fb exclude-writes
-
-# org.bluetooth.characteristic.gap.reconnection_address
-# Disallow messing with connection parameters
-00002a03-0000-1000-8000-00805f9b34fb
 
 
 ## Descriptors


### PR DESCRIPTION
I'm sending this for discussion rather than because I'm sure it's the right thing to do.

@beaufortfrancois, can you double-check that we don't have access to these two services on ChromeOS? I'm curious if we have access on other platforms.

If we block these, we should expose [org.bluetooth.characteristic.gap.appearance](https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.appearance.xml) and [org.bluetooth.characteristic.gap.peripheral_privacy_flag](https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.peripheral_privacy_flag.xml) on `BluetoothDevice`, since users won't have another way to get at them anymore.
