### PR TITLE
Allow access to the GAP and GATT services.

### DIFF
--- a/gatt_blacklist.txt
+++ b/gatt_blacklist.txt
@@ -3,15 +3,6 @@
 
 ## Services
 
-# org.bluetooth.service.generic_access and
-# org.bluetooth.service.generic_attribute
-# These fundamental services are part of the GATT protocol rather than
-# per-device data. Several platforms don't allow the browser to access them
-# directly, and most of their data is exposed through other properties on the
-# BluetoothDevice.
-00001800-0000-1000-8000-00805f9b34fb
-00001801-0000-1000-8000-00805f9b34fb
-
 # org.bluetooth.service.human_interface_device
 # Direct access to HID devices like keyboards would let web pages
 # become keyloggers.
@@ -19,6 +10,14 @@
 
 
 ## Characteristics
+
+# org.bluetooth.characteristic.gap.peripheral_privacy_flag
+# Don't let web pages turn off privacy mode.
+00002a02-0000-1000-8000-00805f9b34fb exclude-writes
+
+# org.bluetooth.characteristic.gap.reconnection_address
+# Disallow messing with connection parameters
+00002a03-0000-1000-8000-00805f9b34fb
 
 # org.bluetooth.characteristic.serial_number_string
 # Block access to standardized unique identifiers, for privacy reasons.


### PR DESCRIPTION
This reverts 95a7927678e4ebae02df111c1eccdbb9713989dd to focus the blacklist more strongly on security instead of implementability concerns.

[GAP service](https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.generic_access.xml) and [GATT service](https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.generic_attribute.xml)

The main feature this allows is writing to the Device Name, which is probably a good thing to allow from the web.

Should we blacklist [Service Changed](https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gatt.service_changed.xml)? The values it indicates are useless to websites, since we don't expose attribute handles in any other way, but the timing might be useful, and I don't see a security issue with exposing the information.

Relevant links about why the state was the way it was:
- https://github.com/WebBluetoothCG/web-bluetooth/issues/24#issuecomment-52347030
- https://crbug.com/532930#c17
- http://article.gmane.org/gmane.linux.bluez.kernel/64774
