### PR TITLE
Add fff9 to blocklist

### DIFF
--- a/gatt_blocklist.txt
+++ b/gatt_blocklist.txt
@@ -33,6 +33,9 @@ f000ffc0-0451-4000-b000-000000000000
 # FIDO device.
 0000fffd-0000-1000-8000-00805f9b34fb
 
+# fff9 is also assigned to FIDO
+0000fff9-0000-1000-8000-00805f9b34fb
+
 # fde2 is assigned to Google and used for pairingless FIDO
 # https://btprodspecificationrefs.blob.core.windows.net/assigned-values/16-bit%20UUID%20Numbers%20Document.pdf
 0000fde2-0000-1000-8000-00805f9b34fb


### PR DESCRIPTION
fff9 is also [assigned to FIDO](https://btprodspecificationrefs.blob.core.windows.net/assigned-values/16-bit%20UUID%20Numbers%20Document.pdf). It's not currently in use but it soon will be as a FIDO-generic version of fde2.